### PR TITLE
Support XPLMGetVersions with a VersionInfo struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ pub mod geometry;
 pub mod menu;
 /// Plugin creation and management
 pub mod plugin;
+/// X-Plane and XPLM version info
+pub mod versions;
 /// Relatively low-level windows
 pub mod window;
 

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,5 +1,6 @@
 use xplm_sys;
 
+#[derive(Debug)]
 pub struct VersionInfo {
     pub xplane_version: i32,
     pub xplm_version: i32,

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -9,17 +9,18 @@ pub struct VersionInfo {
 
 impl VersionInfo {
     pub fn get() -> Self {
-        let xplane_version: *mut i32 = std::ptr::null_mut();
-        let xplm_version: *mut i32 = std::ptr::null_mut();
-        let host_id: *mut i32 = std::ptr::null_mut();
+        let mut xplane_version: i32 = -1;
+        let mut xplm_version: i32 = -1;
+        let mut host_id: i32 = -1;
 
         unsafe {
-            xplm_sys::XPLMGetVersions(xplane_version, xplm_version, host_id);
-            return VersionInfo {
-                xplane_version: *xplane_version.as_ref().unwrap_or(&-1),
-                xplm_version: *xplm_version.as_ref().unwrap_or(&-1),
-                host_id: *host_id.as_ref().unwrap_or(&-1),
-            };
+            xplm_sys::XPLMGetVersions(&mut xplane_version, &mut xplm_version, &mut host_id);
+        }
+
+        VersionInfo {
+            xplane_version,
+            xplm_version,
+            host_id,
         }
     }
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,0 +1,24 @@
+use xplm_sys;
+
+pub struct VersionInfo {
+    pub xplane_version: i32,
+    pub xplm_version: i32,
+    pub host_id: i32,
+}
+
+impl VersionInfo {
+    pub fn get() -> Self {
+        let xplane_version: *mut i32 = std::ptr::null_mut();
+        let xplm_version: *mut i32 = std::ptr::null_mut();
+        let host_id: *mut i32 = std::ptr::null_mut();
+
+        unsafe {
+            xplm_sys::XPLMGetVersions(xplane_version, xplm_version, host_id);
+            return VersionInfo {
+                xplane_version: *xplane_version.as_ref().unwrap_or(&-1),
+                xplm_version: *xplm_version.as_ref().unwrap_or(&-1),
+                host_id: *host_id.as_ref().unwrap_or(&-1),
+            };
+        }
+    }
+}


### PR DESCRIPTION
Hi!

I added a `VersionInfo` struct with a `get` function wrapping `XPLMGetVersions`.

I wasn't too sure about appropriate default values, so I went with -1, but if I understand the documentation for `XPLMGetVersions` correctly, there shouldn't be a case where these ints are not set.