### PR TITLE
Implement XPluginReceiveMessage callback

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,3 +1,5 @@
+use std::os::raw::{c_int, c_void};
+
 /// Accessing and communicating with other plugins
 pub mod management;
 
@@ -39,4 +41,10 @@ pub trait Plugin: Sized {
 
     /// Returns information on this plugin
     fn info(&self) -> PluginInfo;
+
+    #[allow(unused_variables)]
+    /// Called when the plugin receives a message
+    ///
+    /// The default implementation does nothing.
+    fn receive_message(&mut self, from: c_int, message: c_int, param: *mut c_void) {}
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,4 +1,4 @@
-use std::os::raw::{c_int, c_void};
+use std::os::raw::c_void;
 
 /// Accessing and communicating with other plugins
 pub mod management;
@@ -46,5 +46,5 @@ pub trait Plugin: Sized {
     /// Called when the plugin receives a message
     ///
     /// The default implementation does nothing.
-    fn receive_message(&mut self, from: c_int, message: c_int, param: *mut c_void) {}
+    fn receive_message(&mut self, from: i32, message: u32, param: *mut c_void) {}
 }

--- a/src/plugin/internal.rs
+++ b/src/plugin/internal.rs
@@ -148,6 +148,7 @@ pub unsafe fn xplugin_receive_message<P>(
 {
     if !data.panicked {
         let unwind = panic::catch_unwind(AssertUnwindSafe(|| {
+            let message = message as u32;
             (*data.plugin).receive_message(from, message, param);
         }));
         if unwind.is_err() {

--- a/src/plugin_macro.rs
+++ b/src/plugin_macro.rs
@@ -47,14 +47,13 @@ macro_rules! xplane_plugin {
         }
 
         #[allow(non_snake_case)]
-        #[allow(unused_variables)]
         #[no_mangle]
         pub unsafe extern "C" fn XPluginReceiveMessage(
             from: ::std::os::raw::c_int,
             message: ::std::os::raw::c_int,
             param: *mut ::std::os::raw::c_void,
         ) {
-            // Nothing
+            ::xplm::plugin::internal::xplugin_receive_message(&mut PLUGIN, from, message, param)
         }
     };
 }


### PR DESCRIPTION
In my plugin written with the help of `rust-xplm` I needed access to the XPluginReceiveMessage callback.
So I tried to implement it myself.

Since I have no expierence interfacing C libraries from Rust I simply tried to adopt the implementation from the code that is already there.
Reading the X-Plane SDK, the`from` parameter probably should be an `i32`, the `message` parameter should be an `u32`. But I'm not sure on how to handle the `param` parameter.

For my project, I only listen for the `XPLM_MSG_LIVERY_LOADED` message. There, the `param` only contains an index to the affected aircraft and a simple cast to `i32` is sufficient. But other messages may contain different data in `param`.
So for now I just tranparently pass the `param` parameter into the plugin's `receive_message` implementation.