### PR TITLE
Apply Clippy fixes

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -62,7 +62,7 @@ pub struct CommandHold<'a> {
     command: &'a mut Command,
 }
 
-impl<'a> Drop for CommandHold<'a> {
+impl Drop for CommandHold<'_> {
     fn drop(&mut self) {
         self.command.release();
     }
@@ -167,11 +167,11 @@ unsafe extern "C" fn command_handler<H: CommandHandler>(
     let data = refcon as *mut OwnedCommandData;
     let handler: *mut dyn CommandHandler = (*data).handler.deref_mut();
     let handler = handler as *mut H;
-    if phase == xplm_CommandBegin as i32 {
+    if phase == xplm_CommandBegin {
         (*handler).command_begin();
-    } else if phase == xplm_CommandContinue as i32 {
+    } else if phase == xplm_CommandContinue {
         (*handler).command_continue();
-    } else if phase == xplm_CommandEnd as i32 {
+    } else if phase == xplm_CommandEnd {
         (*handler).command_end();
     }
     // Prevent other components from handling this equivalent

--- a/src/data.rs
+++ b/src/data.rs
@@ -46,6 +46,8 @@ pub trait DataReadWrite<T>: DataRead<T> {
 
 /// Trait for readable array data accessors
 pub trait ArrayRead<T: ArrayType + ?Sized> {
+    // Array datarefs always have at least one entry
+    #![allow(clippy::len_without_is_empty)]
     /// Reads values
     ///
     /// Values are stored in the provided slice. If the dataref is larger than the provided slice,

--- a/src/data/owned.rs
+++ b/src/data/owned.rs
@@ -84,84 +84,84 @@ impl<T: DataType + ?Sized, A: Access> OwnedData<T, A> {
         }
     }
     fn int_read() -> XPLMGetDatai_f {
-        if T::sim_type() & xplmType_Int as i32 != 0 {
+        if T::sim_type() & xplmType_Int != 0 {
             Some(int_read)
         } else {
             None
         }
     }
     fn int_write() -> XPLMSetDatai_f {
-        if T::sim_type() & xplmType_Int as i32 != 0 && A::writeable() {
+        if T::sim_type() & xplmType_Int != 0 && A::writeable() {
             Some(int_write)
         } else {
             None
         }
     }
     fn float_read() -> XPLMGetDataf_f {
-        if T::sim_type() & xplmType_Float as i32 != 0 {
+        if T::sim_type() & xplmType_Float != 0 {
             Some(float_read)
         } else {
             None
         }
     }
     fn float_write() -> XPLMSetDataf_f {
-        if T::sim_type() & xplmType_Float as i32 != 0 && A::writeable() {
+        if T::sim_type() & xplmType_Float != 0 && A::writeable() {
             Some(float_write)
         } else {
             None
         }
     }
     fn double_read() -> XPLMGetDatad_f {
-        if T::sim_type() & xplmType_Double as i32 != 0 {
+        if T::sim_type() & xplmType_Double != 0 {
             Some(double_read)
         } else {
             None
         }
     }
     fn double_write() -> XPLMSetDatad_f {
-        if T::sim_type() & xplmType_Double as i32 != 0 && A::writeable() {
+        if T::sim_type() & xplmType_Double != 0 && A::writeable() {
             Some(double_write)
         } else {
             None
         }
     }
     fn int_array_read() -> XPLMGetDatavi_f {
-        if T::sim_type() & xplmType_IntArray as i32 != 0 {
+        if T::sim_type() & xplmType_IntArray != 0 {
             Some(int_array_read)
         } else {
             None
         }
     }
     fn int_array_write() -> XPLMSetDatavi_f {
-        if T::sim_type() & xplmType_IntArray as i32 != 0 && A::writeable() {
+        if T::sim_type() & xplmType_IntArray != 0 && A::writeable() {
             Some(int_array_write)
         } else {
             None
         }
     }
     fn float_array_read() -> XPLMGetDatavf_f {
-        if T::sim_type() & xplmType_FloatArray as i32 != 0 {
+        if T::sim_type() & xplmType_FloatArray != 0 {
             Some(float_array_read)
         } else {
             None
         }
     }
     fn float_array_write() -> XPLMSetDatavf_f {
-        if T::sim_type() & xplmType_FloatArray as i32 != 0 && A::writeable() {
+        if T::sim_type() & xplmType_FloatArray != 0 && A::writeable() {
             Some(float_array_write)
         } else {
             None
         }
     }
     fn byte_array_read() -> XPLMGetDatab_f {
-        if T::sim_type() & xplmType_Data as i32 != 0 {
+        if T::sim_type() & xplmType_Data != 0 {
             Some(byte_array_read)
         } else {
             None
         }
     }
     fn byte_array_write() -> XPLMSetDatab_f {
-        if T::sim_type() & xplmType_Data as i32 != 0 && A::writeable() {
+        if T::sim_type() & xplmType_Data != 0 && A::writeable() {
             Some(byte_array_write)
         } else {
             None

--- a/src/data/owned.rs
+++ b/src/data/owned.rs
@@ -1,7 +1,6 @@
 use super::{Access, ArrayRead, ArrayReadWrite, DataRead, DataReadWrite, DataType, ReadOnly};
 use std::cmp;
 use std::ffi::{CString, NulError};
-use std::i32;
 use std::marker::PhantomData;
 use std::os::raw::{c_int, c_void};
 use std::ptr;

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -99,6 +99,8 @@ pub enum Phase {
 
 impl Phase {
     /// Converts this phase into an XPLMDrawingPhase and a 0 for after or 1 for before
+    // TODO: examine if this warning is applicable and this should be `to_xplm(self)`
+    #[allow(clippy::wrong_self_convention)]
     fn to_xplm(&self) -> xplm_sys::XPLMDrawingPhase {
         use self::Phase::*;
         let phase = match *self {
@@ -175,10 +177,10 @@ pub fn bind_texture(texture_number: i32, texture_id: i32) {
 /// Texture IDs are placed in the provided slice. If the slice contains more than i32::max_value()
 /// elements, no more than i32::max_value() texture IDs will be generated.
 pub fn generate_texture_numbers(numbers: &mut [i32]) {
-    let count = if numbers.len() < (i32::max_value() as usize) {
+    let count = if numbers.len() < (i32::MAX as usize) {
         numbers.len() as i32
     } else {
-        i32::max_value()
+        i32::MAX
     };
     unsafe {
         xplm_sys::XPLMGenerateTextureNumbers(numbers.as_mut_ptr(), count);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -10,7 +10,6 @@
 //! Foreign function interface utilities
 //!
 
-use std::iter;
 use std::os::raw::c_char;
 use std::str;
 use std::str::Utf8Error;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -30,7 +30,7 @@ impl StringBuffer {
     /// set to null bytes (`\0`).
     pub fn new(length: usize) -> StringBuffer {
         StringBuffer {
-            bytes: iter::repeat(b'\0').take(length).collect(),
+            bytes: std::iter::repeat_n(b'\0', length).collect(),
         }
     }
 

--- a/src/flight_loop.rs
+++ b/src/flight_loop.rs
@@ -67,7 +67,7 @@ impl FlightLoop {
         // Create a flight loop
         let mut config = xplm_sys::XPLMCreateFlightLoop_t {
             structSize: mem::size_of::<xplm_sys::XPLMCreateFlightLoop_t>() as c_int,
-            phase: xplm_sys::xplm_FlightLoop_Phase_AfterFlightModel as i32,
+            phase: xplm_sys::xplm_FlightLoop_Phase_AfterFlightModel,
             callbackFunc: Some(flight_loop_callback::<C>),
             refcon: data_ptr as *mut c_void,
         };
@@ -188,7 +188,7 @@ pub struct LoopState<'a> {
     result: &'a mut LoopResult,
 }
 
-impl<'a> LoopState<'a> {
+impl LoopState<'_> {
     /// Returns the duration since the last time this callback was called
     pub fn since_last_call(&self) -> Duration {
         self.since_call

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub fn debug<S: Into<String>>(message: S) {
     match CString::new(message.into()) {
         Ok(message_c) => unsafe { XPLMDebugString(message_c.as_ptr()) },
         Err(_) => unsafe {
-            XPLMDebugString("[xplm] Invalid debug message\n\0".as_ptr() as *const _)
+            XPLMDebugString(c"[xplm] Invalid debug message\n".as_ptr() as *const _)
         },
     }
 }
@@ -104,7 +104,7 @@ pub fn speak<S: Into<String>>(msg: S) {
             xplm_sys::XPLMSpeakString(msg.as_ptr());
         },
         Err(_) => unsafe {
-            crate::XPLMDebugString("[xplm] Invalid speak message\n\0".as_ptr() as *const _)
+            crate::XPLMDebugString(c"[xplm] Invalid speak message\n".as_ptr() as *const _)
         },
     }
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -95,7 +95,7 @@ pub struct Menu {
     /// The items, separators, and submenus in this menu
     ///
     /// Each item is in a Box, to allow callbacks to reference it.
-    children: RefCell<Vec<Box<Item>>>,
+    children: RefCell<Vec<Item>>,
     /// The status of this menu
     state: Cell<MenuState>,
 }
@@ -139,7 +139,7 @@ impl Menu {
         Rc<C>: Into<Item>,
     {
         let mut borrow = self.children.borrow_mut();
-        borrow.push(Box::new(child.into().into()));
+        borrow.push(child.into().into());
     }
 
     /// Adds this menu as a child of the plugins menu

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -370,7 +370,7 @@ impl ActionItem {
 
     fn handle_click(&self) {
         let mut borrow = self.handler.borrow_mut();
-        borrow.item_clicked(&self);
+        borrow.item_clicked(self);
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -8,9 +8,10 @@ use xplm_sys;
 use super::geometry::{Point, Rect};
 
 /// Cursor states that windows can apply
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum Cursor {
     /// X-Plane draws the default cursor
+    #[default]
     Default,
     /// X-Plane draws an arrow cursor (not any other cursor type)
     Arrow,
@@ -26,12 +27,6 @@ impl Cursor {
             Cursor::Arrow => xplm_sys::xplm_CursorArrow as xplm_sys::XPLMCursorStatus,
             Cursor::None => xplm_sys::xplm_CursorHidden as xplm_sys::XPLMCursorStatus,
         }
-    }
-}
-
-impl Default for Cursor {
-    fn default() -> Self {
-        Cursor::Default
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -90,6 +90,8 @@ impl Window {
     /// Creates a new window with the provided geometry and returns a reference to it
     ///
     /// The window is originally not visible.
+    // TODO: determine if Clippy warning about `new` not returning `self` is applicable
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<R: Into<Rect<i32>>, D: WindowDelegate>(geometry: R, delegate: D) -> WindowRef {
         let geometry = geometry.into();
 


### PR DESCRIPTION
There are 30 Clippy warnings, 21 of which can be automatically fixed. This PR suppresses three of them and resolves the others.